### PR TITLE
Implement bounds checks and relocation in BinarySection::resize

### DIFF
--- a/src/boomerang/db/binary/BinarySection.cpp
+++ b/src/boomerang/db/binary/BinarySection.cpp
@@ -14,6 +14,9 @@
 #include "boomerang/util/Util.h"
 #include "boomerang/util/log/Log.h"
 
+#include <algorithm>
+#include <cstring>
+
 
 class BinarySectionImpl
 {
@@ -95,16 +98,63 @@ bool BinarySection::anyDefinedValues() const
 
 void BinarySection::resize(uint32_t sz)
 {
-    LOG_VERBOSE("Function not fully implemented yet");
-    m_size = sz;
+    if (sz == m_size) {
+        return; // nothing to do
+    }
 
-    //    assert(false && "This function is not implmented yet");
-    //    if(sz!=m_Size) {
-    //        const BinarySection *sect =
-    //        Boomerang::get()->getImage()->getSectionByAddr(uNativeAddr+sz); if(sect==nullptr ||
-    //        sect==this ) {
-    //        }
-    //    }
+    const Address newEnd = m_nativeAddr + sz;
+    if (sz > 0 && newEnd < m_nativeAddr) {
+        LOG_ERROR("Cannot resize section '%1' to size %2: address overflow", m_sectionName, sz);
+        return;
+    }
+
+    // relocating existing host data when expanding
+    if (m_hostAddr != HostAddress::INVALID && sz > m_size) {
+        Byte *newData = new (std::nothrow) Byte[sz];
+        if (newData == nullptr) {
+            LOG_ERROR("Cannot resize section '%1' to size %2: allocation failed", m_sectionName,
+                      sz);
+            return;
+        }
+
+        std::memcpy(newData, reinterpret_cast<const void *>(m_hostAddr.value()), m_size);
+        m_hostAddr = HostAddress(newData);
+    }
+
+    if (sz < m_size) {
+        // Truncate defined value ranges and attributes beyond the new end
+        IntervalSet<Address> newDefined;
+        for (const auto &ival : m_impl->m_hasDefinedValue) {
+            Address low  = ival.lower();
+            Address high = ival.upper();
+            if (low >= newEnd) {
+                continue;
+            }
+            if (high > newEnd) {
+                high = newEnd;
+            }
+            newDefined.insert(low, high);
+        }
+        m_impl->m_hasDefinedValue = std::move(newDefined);
+
+        for (auto &attrPair : m_impl->m_attributeMap) {
+            IntervalSet<Address> newSet;
+            for (const auto &ival : attrPair.second) {
+                Address low  = ival.lower();
+                Address high = ival.upper();
+                if (low >= newEnd) {
+                    continue;
+                }
+                if (high > newEnd) {
+                    high = newEnd;
+                }
+                newSet.insert(low, high);
+            }
+            attrPair.second = std::move(newSet);
+        }
+    }
+
+    m_size = sz;
 }
 
 

--- a/tests/unit-tests/boomerang/db/binary/BinarySectionTest.cpp
+++ b/tests/unit-tests/boomerang/db/binary/BinarySectionTest.cpp
@@ -12,6 +12,7 @@
 
 #include "boomerang/db/proc/UserProc.h"
 #include "boomerang/db/binary/BinarySection.h"
+#include "boomerang/util/Types.h"
 
 #include <QByteArray>
 
@@ -50,6 +51,26 @@ void BinarySectionTest::testResize()
     QCOMPARE(section.getSize(), 0x0800);
     section.resize(0x1000);
     QCOMPARE(section.getSize(), 0x1000);
+}
+
+
+void BinarySectionTest::testResizeRelocate()
+{
+    char sectionData[8] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+    BinarySection section(Address(0x2000), sizeof(sectionData), "testSection");
+    section.setHostAddr(HostAddress(sectionData));
+    section.addDefinedArea(Address(0x2000), Address(0x2000) + sizeof(sectionData));
+
+    HostAddress oldHost = section.getHostAddr();
+    section.resize(16);
+
+    QCOMPARE(section.getSize(), 16); // resized
+    QVERIFY(section.getHostAddr() != HostAddress::INVALID);
+    QVERIFY(section.getHostAddr() != oldHost); // relocated
+
+    const Byte *bytes = reinterpret_cast<const Byte *>(section.getHostAddr().value());
+    QCOMPARE(bytes[0], static_cast<Byte>(0));
+    QCOMPARE(bytes[7], static_cast<Byte>(7));
 }
 
 

--- a/tests/unit-tests/boomerang/db/binary/BinarySectionTest.h
+++ b/tests/unit-tests/boomerang/db/binary/BinarySectionTest.h
@@ -23,5 +23,7 @@ private slots:
     void testResize();
     void testAddDefinedArea();
 
+    void testResizeRelocate();
+
     void testAttributes();
 };


### PR DESCRIPTION
## Summary
- add overflow checks and host-memory relocation to BinarySection::resize
- truncate attribute and defined-value ranges when shrinking sections
- test section resizing with host memory relocation

## Testing
- `cmake -S . -B build -DBUILD_TESTING=ON -DCMAKE_CXX_FLAGS='-Wno-error=null-dereference'` *(passed: configured)*
- `cmake --build build` *(failed: build interrupted due to time constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68b11471c824832fac743efa2d2f4135