### PR TITLE
Implement CR1 flag handling for PPC floating ops

### DIFF
--- a/data/ssl/ppc.ssl
+++ b/data/ssl/ppc.ssl
@@ -188,6 +188,13 @@ SETFLAGS0(rd) {
     *1* %CR0@[3:3] := [rd < 0?1:0]
 };
 
+SETFLAGS1(rd) {
+    *1* %CR1@[0:0] := 0                 # Note: these are non IBM bit numbers; LT is most significant bit (PPC bit 0)
+    *1* %CR1@[1:1] := [rd = 0?1:0]
+    *1* %CR1@[2:2] := [rd > 0?1:0]
+    *1* %CR1@[3:3] := [rd < 0?1:0]
+};
+
 
 
 SUBFLAGSNL(op1, op2, crfd) {
@@ -534,9 +541,9 @@ INSTRUCTION "FCTIWZ"          (fd, fb)          { *64* fd := zfill(32, 64, ftoi(
 INSTRUCTION "FCTIWZq"         (fd, fb)          { *64* fd := zfill(32, 64, ftoi(64, 32, fb)) };
 
 INSTRUCTION "FABS"            (fd, fs)          { *64* fd := fabs(fs) };
-INSTRUCTION "FABSq"           (fd, fs)          { *64* fd := fabs(fs) }; # TODO: Update flags
+INSTRUCTION "FABSq"           (fd, fs)          { *64* fd := fabs(fs)              SETFLAGS1(fd) };
 INSTRUCTION "FNABS"           (fd, fs)          { *64* fd := 0.0 -f fabs(fs) };
-INSTRUCTION "FNABSq"          (fd, fs)          { *64* fd := 0.0 -f fabs(fs) }; # TODO: Update flags
+INSTRUCTION "FNABSq"          (fd, fs)          { *64* fd := 0.0 -f fabs(fs)     SETFLAGS1(fd) };
 
 INSTRUCTION "FADD"            (fd, fa, fb)      {  *64* fd := fa +f fb };
 INSTRUCTION "FADDq"           (fd, fa, fb)      { *64* fd := fa +f fb };        # Note: floating point flags not implemented yet
@@ -559,14 +566,14 @@ INSTRUCTION "FDIVS"           (fd, fa, fb)      { *64* fd := fa /f fb };        
 INSTRUCTION "FDIVSq"          (fd, fa, fb)      { *64* fd := fa /f fb };        # Yet result is in 64-bit format
 
 INSTRUCTION "FMADD"           (ft, fa, fc, fb)  { *64* ft := (fa *f fc) +f fb };
-INSTRUCTION "FMADDq"          (ft, fa, fc, fb)  { *64* ft := (fa *f fc) +f fb }; # TODO: Update flags
+INSTRUCTION "FMADDq"          (ft, fa, fc, fb)  { *64* ft := (fa *f fc) +f fb     SETFLAGS1(ft) };
 INSTRUCTION "FMADDS"          (ft, fa, fc, fb)  { *64* ft := (fa *f fc) +f fb };
-INSTRUCTION "FMADDSq"         (ft, fa, fc, fb)  { *64* ft := (fa *f fc) +f fb }; # TODO: Update flags
+INSTRUCTION "FMADDSq"         (ft, fa, fc, fb)  { *64* ft := (fa *f fc) +f fb     SETFLAGS1(ft) };
 
 INSTRUCTION "FMSUB"           (ft, fa, fc, fb)  { *64* ft := (fa *f fc) -f fb };
-INSTRUCTION "FMSUBq"          (ft, fa, fc, fb)  { *64* ft := (fa *f fc) -f fb }; # TODO: Update flags
+INSTRUCTION "FMSUBq"          (ft, fa, fc, fb)  { *64* ft := (fa *f fc) -f fb     SETFLAGS1(ft) };
 INSTRUCTION "FMSUBS"          (ft, fa, fc, fb)  { *64* ft := (fa *f fc) -f fb };
-INSTRUCTION "FMSUBSq"         (ft, fa, fc, fb)  { *64* ft := (fa *f fc) -f fb }; # TODO: Update flags
+INSTRUCTION "FMSUBSq"         (ft, fa, fc, fb)  { *64* ft := (fa *f fc) -f fb     SETFLAGS1(ft) };
 
 INSTRUCTION "FNMADD"          (ft, fa, fc, fb)  { *64* ft := 0.0 -f ((fa *f fc) +f fb) };
 INSTRUCTION "FNMADDq"         (ft, fa, fc, fb)  { *64* ft := 0.0 -f ((fa *f fc) +f fb) };

--- a/tests/unit-tests/boomerang-plugins/decoder/ppc/CapstonePPCDecoderTest.cpp
+++ b/tests/unit-tests/boomerang-plugins/decoder/ppc/CapstonePPCDecoderTest.cpp
@@ -474,6 +474,7 @@ void CapstonePPCDecoderTest::testInstructions_data()
 
     TEST_DECODE("fabs. 1, 2", "\xfc\x20\x12\x11",
                 "0x00001000    0 *64* r33 := fabs(r34)\n"
+                "              0 *v* %flags := SETFLAGS1( r33 )\n",
     );
 
     TEST_DECODE("fadd 1, 2, 3", "\xfc\x22\x18\x2a",
@@ -532,6 +533,7 @@ void CapstonePPCDecoderTest::testInstructions_data()
 
     TEST_DECODE("fmadd. 4, 2, 5, 1", "\xfc\x82\x09\x7b",
                 "0x00001000    0 *64* r36 := (r34 *f r37) +f r33\n"
+                "              0 *v* %flags := SETFLAGS1( r36 )\n",
     );
 
     TEST_DECODE("fmadds 4, 2, 5, 1", "\xec\x82\x09\x7a",
@@ -540,6 +542,7 @@ void CapstonePPCDecoderTest::testInstructions_data()
 
     TEST_DECODE("fmadds. 4, 2, 5, 1", "\xec\x82\x09\x7b",
                 "0x00001000    0 *64* r36 := (r34 *f r37) +f r33\n"
+                "              0 *v* %flags := SETFLAGS1( r36 )\n",
     );
 
     TEST_DECODE("fmr 3, 1", "\xfc\x60\x08\x90",
@@ -556,6 +559,7 @@ void CapstonePPCDecoderTest::testInstructions_data()
 
     TEST_DECODE("fmsub. 4, 2, 5, 1", "\xfc\x82\x09\x79",
                 "0x00001000    0 *64* r36 := (r34 *f r37) -f r33\n"
+                "              0 *v* %flags := SETFLAGS1( r36 )\n",
     );
 
     TEST_DECODE("fmsubs 4, 2, 5, 1", "\xec\x82\x09\x78",
@@ -564,6 +568,7 @@ void CapstonePPCDecoderTest::testInstructions_data()
 
     TEST_DECODE("fmsubs. 4, 2, 5, 1", "\xec\x82\x09\x79",
                 "0x00001000    0 *64* r36 := (r34 *f r37) -f r33\n"
+                "              0 *v* %flags := SETFLAGS1( r36 )\n",
     );
 
     TEST_DECODE("fmul 3, 1, 2", "\xfc\x61\x00\xb2",
@@ -588,6 +593,7 @@ void CapstonePPCDecoderTest::testInstructions_data()
 
     TEST_DECODE("fnabs. 4, 2", "\xfc\x80\x11\x11",
                 "0x00001000    0 *64* r36 := -fabs(r34)\n"
+                "              0 *v* %flags := SETFLAGS1( r36 )\n",
     );
 
     TEST_DECODE("fneg 3, 1",  "\xfc\x60\x08\x50",


### PR DESCRIPTION
## Summary
- add SETFLAGS1 helper for updating CR1
- set flags in PPC FABSq/FNABSq/FMADDq/FMADDSq/FMSUBq/FMSUBSq
- test flag-setting for fabs., fnabs., fmadd., fmsub. variants

## Testing
- `cmake -S . -B build -DBUILD_TESTS=ON` *(fails: Could NOT find Capstone)*
- `apt-get install -y qtbase5-dev` *(to install Qt5 dev files)*
- `apt-get install -y libcapstone-dev` *(to install Capstone)*
- `apt-get install -y flex` *(to install Flex)*
- `cmake -S . -B build -DBUILD_TESTS=ON` *(passes)*
- `cmake --build build -- -j2` *(fails: potential null pointer dereference)*

------
https://chatgpt.com/codex/tasks/task_e_68b11472d454832f8188319886ca1466