### PR TITLE
Fix stdio fread/fwrite buffer types

### DIFF
--- a/data/signatures/stdlib/stdio.h
+++ b/data/signatures/stdlib/stdio.h
@@ -48,10 +48,8 @@ int puts(const char *str);
 int ungetc(int character, FILE *stream);
 
 // Direct input/output
-// FIXME the true type for buf is void *, but changing to the correct type breaks
-// regression tests.
-size_t fread(char *buf, size_t size, size_t count, FILE *stream);
-size_t fwrite(const char *buf, size_t size, size_t count, FILE *stream);
+size_t fread(void *buf, size_t size, size_t count, FILE *stream);
+size_t fwrite(const void *buf, size_t size, size_t count, FILE *stream);
 
 // file positioning
 int fgetpos(FILE *stream, fpos_t *pos);


### PR DESCRIPTION
## Summary
- Correct `fread` and `fwrite` signatures in stdlib `stdio.h` to use `void*` and `const void*` buffer parameters.

## Testing
- `python3 tests/regression-tests/regression-tester.py ./boomerang` *(fails: unable to execute regression tests without built Boomerang CLI)*

------
https://chatgpt.com/codex/tasks/task_e_68b11473e49c832f82c6da0f9bacebe5