### PR TITLE
Add loader interface for debug symbols

### DIFF
--- a/src/boomerang-plugins/loader/pe/Win32BinaryLoader.cpp
+++ b/src/boomerang-plugins/loader/pe/Win32BinaryLoader.cpp
@@ -38,6 +38,11 @@ namespace dbghelp
 #include "boomerang/db/binary/BinarySection.h"
 #include "boomerang/db/binary/BinarySymbol.h"
 #include "boomerang/db/binary/BinarySymbolTable.h"
+#include "boomerang/db/proc/Proc.h"
+#include "boomerang/db/signature/Signature.h"
+#include "boomerang/frontend/SigEnum.h"
+#include "boomerang/ssl/exp/Location.h"
+#include "boomerang/util/OStream.h"
 #include "boomerang/util/Util.h"
 #include "boomerang/util/log/Log.h"
 
@@ -45,6 +50,12 @@ namespace dbghelp
 #include <QString>
 
 #include <stdexcept>
+
+
+#if defined(_WIN32) && !defined(__MINGW32__)
+BOOL CALLBACK addSymbol(dbghelp::PSYMBOL_INFO symInfo, ULONG SymbolSize, PVOID UserContext);
+SharedType typeFromDebugInfo(int index, DWORD64 ModBase);
+#endif
 
 
 extern "C"
@@ -1182,6 +1193,66 @@ Address Win32BinaryLoader::getJumpTarget(Address addr) const
 
     // Note: for backwards jumps, this wraps around since we have unsigned integers
     return Address(addr + 5 + disp);
+}
+
+bool Win32BinaryLoader::fetchDebugInfo(Function *function)
+{
+#if !defined(_WIN32) || defined(__MINGW32__)
+    Q_UNUSED(function);
+    LOG_VERBOSE("Adding debug information for Windows programs is only supported on Windows!");
+    return false;
+#else
+    if (!function) {
+        return false;
+    }
+
+    HANDLE hProcess           = GetCurrentProcess();
+    dbghelp::SYMBOL_INFO *sym = (dbghelp::SYMBOL_INFO *)malloc(sizeof(dbghelp::SYMBOL_INFO) + 1000);
+    sym->SizeOfStruct         = sizeof(*sym);
+    sym->MaxNameLen           = 1000;
+    sym->Name[0]              = 0;
+    BOOL got = dbghelp::SymFromAddr(hProcess, function->getEntryAddress().value(), 0, sym);
+    DWORD retType;
+
+    if (got && *sym->Name &&
+        dbghelp::SymGetTypeInfo(hProcess, sym->ModBase, sym->TypeIndex, dbghelp::TI_GET_TYPE,
+                                &retType)) {
+        DWORD d;
+        got = dbghelp::SymGetTypeInfo(hProcess, sym->ModBase, sym->TypeIndex,
+                                      dbghelp::TI_GET_CALLING_CONVENTION, &d);
+
+        if (got) {
+            LOG_VERBOSE("calling convention: %1", (int)d);
+        }
+        else {
+            function->setSignature(
+                Signature::instantiate(Machine::X86, CallConv::C, function->getName()));
+        }
+
+        SharedType rtype = typeFromDebugInfo(retType, sym->ModBase);
+
+        if (!rtype->isVoid()) {
+            function->getSignature()->addReturn(rtype, Location::regOf(REG_X86_EAX));
+        }
+
+        dbghelp::IMAGEHLP_STACK_FRAME stack;
+        stack.InstructionOffset = function->getEntryAddress().value();
+        dbghelp::SymSetContext(hProcess, &stack, 0);
+        dbghelp::SymEnumSymbols(hProcess, 0, nullptr, addSymbol, function);
+
+        QString str;
+        OStream os(&str);
+        function->getSignature()->print(os);
+
+        LOG_VERBOSE("Retrieved Win32 debugging information:");
+        LOG_VERBOSE("%1", str);
+        free(sym);
+        return true;
+    }
+
+    free(sym);
+    return false;
+#endif
 }
 
 

--- a/src/boomerang-plugins/loader/pe/Win32BinaryLoader.h
+++ b/src/boomerang-plugins/loader/pe/Win32BinaryLoader.h
@@ -15,6 +15,8 @@
 
 #include <string>
 
+class Function;
+
 /**
  * This file contains the definition of the Win32BinaryLoader class.
  *
@@ -186,6 +188,9 @@ public:
 public:
     /// \copydoc IFileLoader::getJumpTarget
     Address getJumpTarget(Address addr) const override;
+
+    /// \copydoc IFileLoader::fetchDebugInfo
+    bool fetchDebugInfo(Function *function) override;
 
     /// \copydoc IFileLoader::hasDebugInfo
     bool hasDebugInfo() const override { return m_hasDebugInfo; }

--- a/src/boomerang/db/binary/BinaryFile.cpp
+++ b/src/boomerang/db/binary/BinaryFile.cpp
@@ -89,7 +89,7 @@ Address BinaryFile::getJumpTarget(Address addr) const
 
 bool BinaryFile::hasDebugInfo() const
 {
-    return false;
+    return m_loader ? m_loader->hasDebugInfo() : false;
 }
 
 

--- a/src/boomerang/db/binary/BinaryFile.h
+++ b/src/boomerang/db/binary/BinaryFile.h
@@ -68,6 +68,9 @@ public:
     BinarySymbolTable *getSymbols();
     const BinarySymbolTable *getSymbols() const;
 
+    IFileLoader *getLoader() { return m_loader; }
+    const IFileLoader *getLoader() const { return m_loader; }
+
 public:
     /// \returns the file format of the binary file.
     LoadFmt getFormat() const;

--- a/src/boomerang/db/module/Module.cpp
+++ b/src/boomerang/db/module/Module.cpp
@@ -19,30 +19,10 @@
 #include "boomerang/ssl/exp/Location.h"
 #include "boomerang/ssl/statements/CallStatement.h"
 #include "boomerang/util/log/Log.h"
+#include "boomerang/ifc/IFileLoader.h"
 
 #include <QDir>
 #include <QString>
-
-
-#if defined(_WIN32) && !defined(__MINGW32__)
-#    include <windows.h>
-namespace dbghelp
-{
-#    include <dbghelp.h>
-}
-
-#    include "boomerang/util/log/Log.h"
-
-#    include <iostream>
-#endif
-
-
-#if defined(_WIN32) && !defined(__MINGW32__)
-// From prog.cpp
-BOOL CALLBACK addSymbol(dbghelp::PSYMBOL_INFO symInfo, ULONG SymbolSize, PVOID UserContext);
-SharedType typeFromDebugInfo(int index, DWORD64 ModBase);
-
-#endif
 
 
 void Module::updateLibrarySignatures()
@@ -198,72 +178,6 @@ void Module::setLocationMap(Address loc, Function *fnc)
 }
 
 
-void Module::addWin32DbgInfo(Function *function)
-{
-#if !defined(_WIN32) || defined(__MINGW32__)
-    Q_UNUSED(function);
-    LOG_VERBOSE("Adding debug information for Windows programs is only supported on Windows!");
-    return;
-#else
-    if (!function) {
-        return;
-    }
-    else if (!m_prog || !m_prog->isWin32()) {
-        LOG_WARN("Cannot add debugging information for function '%1'", function->getName());
-        return;
-    }
-
-    // use debugging information
-    HANDLE hProcess           = GetCurrentProcess();
-    dbghelp::SYMBOL_INFO *sym = (dbghelp::SYMBOL_INFO *)malloc(sizeof(dbghelp::SYMBOL_INFO) + 1000);
-    sym->SizeOfStruct         = sizeof(*sym);
-    sym->MaxNameLen           = 1000;
-    sym->Name[0]              = 0;
-    BOOL got = dbghelp::SymFromAddr(hProcess, function->getEntryAddress().value(), 0, sym);
-    DWORD retType;
-
-    if (got && *sym->Name &&
-        dbghelp::SymGetTypeInfo(hProcess, sym->ModBase, sym->TypeIndex, dbghelp::TI_GET_TYPE,
-                                &retType)) {
-        DWORD d;
-        // get a calling convention
-        got = dbghelp::SymGetTypeInfo(hProcess, sym->ModBase, sym->TypeIndex,
-                                      dbghelp::TI_GET_CALLING_CONVENTION, &d);
-
-        if (got) {
-            LOG_VERBOSE("calling convention: %1", (int)d);
-            // TODO: use it
-        }
-        else {
-            // assume we're stdc calling convention, remove r28, r24 returns
-            function->setSignature(
-                Signature::instantiate(Machine::X86, CallConv::C, function->getName()));
-        }
-
-        // get a return type
-        SharedType rtype = typeFromDebugInfo(retType, sym->ModBase);
-
-        if (!rtype->isVoid()) {
-            function->getSignature()->addReturn(rtype, Location::regOf(REG_X86_EAX));
-        }
-
-        // find params and locals
-        dbghelp::IMAGEHLP_STACK_FRAME stack;
-        stack.InstructionOffset = function->getEntryAddress().value();
-        dbghelp::SymSetContext(hProcess, &stack, 0);
-        dbghelp::SymEnumSymbols(hProcess, 0, nullptr, addSymbol, function);
-
-        QString str;
-        OStream os(&str);
-        function->getSignature()->print(os);
-
-        LOG_VERBOSE("Retrieved Win32 debugging information:");
-        LOG_VERBOSE("%1", str);
-    }
-#endif
-}
-
-
 Function *Module::createFunction(const QString &name, Address entryAddr, bool libraryFunction)
 {
     Function *function;
@@ -283,9 +197,11 @@ Function *Module::createFunction(const QString &name, Address entryAddr, bool li
     m_functionList.push_back(function); // Append this to list of procs
     m_prog->getProject()->alertFunctionCreated(function);
 
-    // TODO: add platform agnostic way of using debug information, should be moved to Loaders, Prog
-    // should just collect info from Loader
-    addWin32DbgInfo(function);
+    if (m_prog && m_prog->getBinaryFile() && m_prog->getBinaryFile()->hasDebugInfo()) {
+        if (IFileLoader *loader = m_prog->getBinaryFile()->getLoader()) {
+            loader->fetchDebugInfo(function);
+        }
+    }
     return function;
 }
 

--- a/src/boomerang/db/module/Module.h
+++ b/src/boomerang/db/module/Module.h
@@ -113,10 +113,6 @@ public:
     void updateLibrarySignatures();
 
 private:
-    /// Retrieve Win32 PDB debug information for the function \p function
-    void addWin32DbgInfo(Function *function);
-
-private:
     FunctionList m_functionList; ///< The Functions in the module
     FunctionMap m_labelsToProcs;
 

--- a/src/boomerang/ifc/IFileLoader.h
+++ b/src/boomerang/ifc/IFileLoader.h
@@ -17,6 +17,7 @@
 class Project;
 
 class QIODevice;
+class Function;
 
 
 /**
@@ -89,6 +90,14 @@ public:
     {
         Q_UNUSED(addr);
         return Address::INVALID;
+    }
+
+    /// Populate debug information for \p function if available.
+    /// \returns true if any information was added.
+    virtual bool fetchDebugInfo(Function *function)
+    {
+        Q_UNUSED(function);
+        return false;
     }
     virtual bool hasDebugInfo() const { return false; }
 };


### PR DESCRIPTION
## Summary
- add fetchDebugInfo interface to loaders
- hook Module::createFunction to use loader-provided debug info
- implement fetchDebugInfo in Win32BinaryLoader

## Testing
- `clang-format -i src/boomerang/ifc/IFileLoader.h src/boomerang/db/binary/BinaryFile.h src/boomerang/db/binary/BinaryFile.cpp src/boomerang/db/module/Module.h src/boomerang/db/module/Module.cpp src/boomerang-plugins/loader/pe/Win32BinaryLoader.h src/boomerang-plugins/loader/pe/Win32BinaryLoader.cpp` (fails: duplicated mapping key 'ConstructorInitializerIndentWidth')
- `ctest` (fails: No test configuration file found)
- `make test` (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_68b11474fe48832fae058e34bc51565e