### PR TITLE
Use width-agnostic address reader for globals

### DIFF
--- a/src/boomerang/db/Global.cpp
+++ b/src/boomerang/db/Global.cpp
@@ -71,7 +71,7 @@ SharedExp Global::readInitialValue(Address uaddr, SharedType type) const
 
     if (type->resolvesToPointer()) {
         Address initAddr = Address::INVALID;
-        if (!image->readNativeAddr4(uaddr, initAddr) || initAddr.isZero()) {
+        if (!image->readNativeAddr(uaddr, initAddr) || initAddr.isZero()) {
             return Const::get(0);
         }
 

--- a/src/boomerang/db/binary/BinaryImage.cpp
+++ b/src/boomerang/db/binary/BinaryImage.cpp
@@ -143,6 +143,16 @@ bool BinaryImage::readNativeAddr8(Address addr, Address &value) const
 }
 
 
+bool BinaryImage::readNativeAddr(Address addr, Address &value) const
+{
+    switch (Address::getSourceBits()) {
+    case 64: return readNativeAddr8(addr, value);
+    case 32: return readNativeAddr4(addr, value);
+    default: return false;
+    }
+}
+
+
 bool BinaryImage::readNativeFloat4(Address addr, float &value) const
 {
     const BinarySection *sect = getSectionByAddr(addr);

--- a/src/boomerang/db/binary/BinaryImage.h
+++ b/src/boomerang/db/binary/BinaryImage.h
@@ -111,6 +111,7 @@ public:
 
     bool readNativeAddr4(Address addr, Address &value) const;
     bool readNativeAddr8(Address addr, Address &value) const;
+    bool readNativeAddr(Address addr, Address &value) const;
 
     bool readNativeFloat4(Address addr, float &value) const;
     bool readNativeFloat8(Address addr, double &value) const;


### PR DESCRIPTION
## Summary
- add `readNativeAddr` helper selecting 32- or 64-bit reads based on program bitness
- use the helper in `Global::readInitialValue` to load initial pointers

## Testing
- `cmake -S . -B build` *(fails: Could NOT find FLEX)*
- `sudo apt-get install -y flex bison` *(to install missing dependencies)*
- `cmake -S . -B build`
- `cmake --build build` *(fails: potential null pointer dereference)*

------
https://chatgpt.com/codex/tasks/task_e_68b11476ca54832f868efc659c56a655